### PR TITLE
Remove Hardlink to CA bundle

### DIFF
--- a/config/software/cacerts.rb
+++ b/config/software/cacerts.rb
@@ -47,7 +47,7 @@ build do
 
   # Windows does not support symlinks
   unless windows?
-    link "#{install_dir}/embedded/ssl/certs/cacert.pem", "#{install_dir}/embedded/ssl/cert.pem"
+    link "certs/cacert.pem", "#{install_dir}/embedded/ssl/cert.pem"
 
     block { File.chmod(0644, "#{install_dir}/embedded/ssl/certs/cacert.pem") }
   end


### PR DESCRIPTION
CPIO does not like the hard link... Use a symlink instead.

### Description

This should fix the Docker build.  `cpio` was erroring out about an unsafe symlink.

```
cpio: skipping unsafe symlink to '/opt/chef/embedded/ssl/certs/cacert.pem' in archive, set EXTRACT_UNSAFE_SYMLINKS=1 to extract
```

### TODOs

Was a software definition added? Or a new version to an existing definition?
- [ ] (Chef employee) If this is not a minor change, verify with an ad-hoc build of Automate, Chef-DK, or Chef Server (if applicable -- ask @londo to find out).

--------------------------------------------------
